### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/eik-lib/prettier-config.git"
+    "url": "git+https://github.com/eik-lib/prettier-config.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- update repository metadata from the SSH GitHub URL to the public HTTPS Git URL
- leave package contents, version, homepage, bugs URL, license, and peer dependencies unchanged

## Validation
- `npm view @eik/prettier-config@1.0.2 name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if (p.name !== '@eik/prettier-config') throw new Error('wrong package'); if (p.repository.url !== 'git+https://github.com/eik-lib/prettier-config.git') throw new Error('repository metadata missing'); if (p.homepage !== 'https://github.com/eik-lib/prettier-config#readme') throw new Error('homepage changed'); if (p.bugs.url !== 'https://github.com/eik-lib/prettier-config/issues') throw new Error('bugs changed'); console.log('metadata ok')"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`